### PR TITLE
Use new `CrawlingLogsMiddleware`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Scrapy==2.11.0
-zyte-spider-templates==0.2.0
+zyte-spider-templates==0.3.0

--- a/zyte_spider_templates_project/settings.py
+++ b/zyte_spider_templates_project/settings.py
@@ -20,7 +20,7 @@ SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"
 SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
 SPIDER_MIDDLEWARES = {
     "scrapy_poet.RetryMiddleware": 275,
-    "zyte_crawlers.middlewares.CrawlingLogsMiddleware": 1000,
+    "zyte_spider_templates.middlewares.CrawlingLogsMiddleware": 1000,
 }
 TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
 

--- a/zyte_spider_templates_project/settings.py
+++ b/zyte_spider_templates_project/settings.py
@@ -20,6 +20,7 @@ SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"
 SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
 SPIDER_MIDDLEWARES = {
     "scrapy_poet.RetryMiddleware": 275,
+    "zyte_crawlers.middlewares.CrawlingLogsMiddleware": 1000,
 }
 TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
 


### PR DESCRIPTION
Following https://github.com/zytedata/zyte-spider-templates/pull/10, we need to activate the new `CrawlingLogsMiddleware`.

NOTE: This assumes that `zyte-spider-templates==0.3.0` has been released. Let's only merge it when this happens.