### PR TITLE
increase `CLOSESPIDER_TIMEOUT_NO_ITEM` from 600 to 900

### DIFF
--- a/zyte_spider_templates_project/settings.py
+++ b/zyte_spider_templates_project/settings.py
@@ -11,7 +11,7 @@ SPIDER_MODULES = [
 ]
 NEWSPIDER_MODULE = "zyte_spider_templates_project.spiders"
 
-CLOSESPIDER_TIMEOUT_NO_ITEM = 600
+CLOSESPIDER_TIMEOUT_NO_ITEM = 900
 ADDONS = {
     "scrapy_zyte_api.Addon": 500,
 }


### PR DESCRIPTION
# Problem

It has been observed that in some websites, the spider can run into some pages which doesn't contain any products at all. This leads to some plateaus in the item growth _(see images below):_

![image](https://github.com/zytedata/zyte-spider-templates-project/assets/3449761/85032890-986c-43c2-acdc-10ba32372daa)

![image](https://github.com/zytedata/zyte-spider-templates-project/assets/3449761/36bc9a39-ff71-4b64-8000-5d280f582575)

If the item count plateaus for more than 10 minutes, then the spider would be closed with a `closespider_timeout_no_item` message.

In most cases, these plateaus are pretty much okay. However, if the RPM slows down when crawling the same website, then it would likely lead to `closespider_timeout_no_item`.

# Proposal

Increasing the `CLOSESPIDER_TIMEOUT_NO_ITEM` setting to a higher value would likely alleviate most cases. I'm not too sure about the best value here but we have to be careful in not setting it too high. 

I'm open to suggestions for any value increase that you think would be the best.