### PR TITLE
bump zyte-spider-templates 0.7.2 → 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Scrapy==2.11.2
 scrapy-zyte-api[provider]>=0.17.3
-zyte-spider-templates==0.7.2
+zyte-spider-templates==0.8.0
 duplicate-url-discarder[rules]>=0.2.0


### PR DESCRIPTION
TODO:

- [x] Merge after `0.8.0` from https://github.com/zytedata/zyte-spider-templates/pull/58 is released