### PR TITLE
Enable the aggresive retry policy by default

### DIFF
--- a/zyte_spider_templates_project/settings.py
+++ b/zyte_spider_templates_project/settings.py
@@ -31,6 +31,9 @@ SCRAPY_POET_DISCOVER = [
     "zyte_spider_templates_project.pages",
 ]
 
+# scrapy-zyte-api
+ZYTE_API_RETRY_POLICY = "zyte_api.aggressive_retrying"
+
 # duplicate-url-discarder
 DUD_ATTRIBUTES_PER_ITEM = {
     "zyte_common_items.Product": [


### PR DESCRIPTION
Tests with SERP showed a few random HTTP 500 responses that do not get retried at all. We either change the default retry policy upstream to retry unexpected HTTP 5xx responses by default, or we enable the aggressive retry policy here.

I am slightly in favor of the alternative approach to be honest, but I suspect this approach may be easier to agree on.