### PR TITLE
Clean the logs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+scrapinghub[msgpack]  # zyte-spider-templates dep, use [msgpack] for speed.
 Scrapy==2.12.0
 scrapy-zyte-api[provider]>=0.22.1
 zyte-spider-templates==0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+duplicate-url-discarder[rules]>=0.3.0
 scrapinghub[msgpack]  # zyte-spider-templates dep, use [msgpack] for speed.
 Scrapy==2.12.0
-scrapy-zyte-api[provider]>=0.22.1
-zyte-spider-templates==0.11.1
-duplicate-url-discarder[rules]>=0.2.0
+scrapy-zyte-api[provider]>=0.25.2
+zyte-spider-templates==0.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Scrapy==2.11.2
+Scrapy==2.12.0
 scrapy-zyte-api[provider]>=0.22.1
 zyte-spider-templates==0.11.1
 duplicate-url-discarder[rules]>=0.2.0

--- a/scrapinghub.yml
+++ b/scrapinghub.yml
@@ -5,6 +5,6 @@
 #projects:
 #  default: NNNNNN
 stacks:
-  default: scrapy:2.11-20241022
+  default: scrapy:2.12-20241202
 requirements:
   file: requirements.txt

--- a/zyte_spider_templates_project/settings.py
+++ b/zyte_spider_templates_project/settings.py
@@ -1,4 +1,7 @@
+from logging import INFO
+
 from itemadapter import ItemAdapter
+from scrapy.logformatter import LogFormatter, DROPPEDMSG
 from zyte_common_items import ZyteItemAdapter
 
 ItemAdapter.ADAPTER_CLASSES.appendleft(ZyteItemAdapter)
@@ -24,6 +27,22 @@ DOWNLOADER_MIDDLEWARES = {
 SPIDER_MIDDLEWARES = {
     "scrapy_poet.RetryMiddleware": 275,
 }
+
+
+class CustomLogFormatter(LogFormatter):
+    def dropped(self, item, exception, response, spider):
+        return {
+            'level': INFO,
+            'msg': DROPPEDMSG,
+            'args': {
+                'exception': exception,
+                'item': item,
+            }
+        }
+
+
+LOG_FORMATTER = CustomLogFormatter
+
 
 # scrapy-poet
 SCRAPY_POET_DISCOVER = [


### PR DESCRIPTION
To do:
- [Stack](https://github.com/scrapinghub/scrapinghub-stack-scrapy)
  - [ ] [scrapy-pagestorage](https://github.com/scrapy-plugins/scrapy-pagestorage) breaks with Scrapy 2.12+, causing a warning about a (Scrapy Cloud) add-on import error. We could either remove the package from the stack (and the corresponding plugin from Scrapy Cloud?) or update the package to support centralized request fingerprinting.
- [x] https://github.com/scrapinghub/scrapy-poet/pull/214
- [x] https://github.com/scrapy-plugins/scrapy-zyte-api/pull/237
- [x] https://github.com/zytedata/zyte-spider-templates/pull/112
- [x] https://github.com/zytedata/duplicate-url-discarder/pull/28
- [ ] https://github.com/zytedata/zyte-common-items/pull/126
- [scrapinghub](https://github.com/scrapinghub/python-scrapinghub) (article spider with incremental)
  - [ ] `SHUB_JOBAUTH` warnings [¹](https://github.com/scrapinghub/python-scrapinghub/blob/a7391717657b2aa1fb88cc4321a829e8ec4aa4a9/scrapinghub/client/utils.py#L113-L114) [²](https://github.com/scrapinghub/python-scrapinghub/blob/a7391717657b2aa1fb88cc4321a829e8ec4aa4a9/scrapinghub/legacy.py#L65-L66)
  - [x] `msgpack` warning
- [ ] https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/pull/91
- [ ] [cookie warning](https://github.com/scrapy-plugins/scrapy-zyte-api/blob/aebc3f400843403b89028944b17a4cfed6a6bbdf/scrapy_zyte_api/_params.py#L1078-L1092) (disable cookies or enable scrapy-zyte-api mapping)

